### PR TITLE
fixed initial path provided in uri getting lost

### DIFF
--- a/src/main/groovy/com/nike/mm/service/impl/HttpRequestService.groovy
+++ b/src/main/groovy/com/nike/mm/service/impl/HttpRequestService.groovy
@@ -17,11 +17,11 @@ class HttpRequestService implements IHttpRequestService {
 
 		http.ignoreSSLIssues()
 
-		if(httpRequestDto.proxyDto.setProxy) {
-			http.setProxy(httpRequestDto.proxyDto.url, httpRequestDto.proxyDto.port,null)
+		if(httpRequestDto.proxyDto?.setProxy) {
+			http.setProxy(httpRequestDto.proxyDto.url, httpRequestDto.proxyDto.port, null)
 		}
 		http.request( GET, JSON ) { req ->
-			uri.path = httpRequestDto.path
+			uri.path = http.getUri().getPath() + httpRequestDto.path
 			if(httpRequestDto.query) {
 				uri.query = httpRequestDto.query
 			}


### PR DESCRIPTION
Hi,

currently reading your incredibly great MEAP and started setting up the system in our environment :)

I stumbled over the issue that if the uri contained already a path like http://host/pathToJira, "pathToJira" got overwritten during request construction in HttpRequestService and fixed an NPE if no proxy was given.

Maybe you wanna incorporate.

Cheers
Sebastian
